### PR TITLE
Remove "create tsid cache" command.

### DIFF
--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -188,15 +188,9 @@ func (c *Curator) updateTsmonLoop() {
 
 	for {
 		c.blockIfNotLeader()
-		if ids, err := c.stateHandler.GetKnownTSIDs(); err == core.NoError {
-			c.tsMon.updateExpected(ids)
-			log.Infof("@@@ tsmon: %s", c.tsMon)
-		} else {
-			log.Infof("creating tsid cache...")
-			err = c.stateHandler.CreateTSIDCache()
-			log.Infof("created tsid cache: %s", err)
-			continue
-		}
+		ids := c.stateHandler.GetKnownTSIDs()
+		c.tsMon.updateExpected(ids)
+		log.Infof("@@@ tsmon: %s", c.tsMon)
 		<-scanTicker.C
 	}
 }

--- a/internal/curator/durable/commands.go
+++ b/internal/curator/durable/commands.go
@@ -42,7 +42,6 @@ func init() {
 	gob.Register(CommitRSChunkCommand{})
 	gob.Register(UpdateRSHostsCommand{})
 	gob.Register(UpdateStorageClassCommand{})
-	gob.Register(CreateTSIDCacheCommand{})
 }
 
 // SetReadOnlyModeCommand changes the read-only mode of the curator's state.
@@ -246,11 +245,6 @@ type UpdateRSHostsCommand struct {
 type UpdateStorageClassCommand struct {
 	ID      core.BlobID
 	Storage core.StorageClass
-}
-
-// CreateTSIDCacheCommand tells the curator to create the TSID cache in the
-// database.
-type CreateTSIDCacheCommand struct {
 }
 
 // cmdToBytes wraps 'cmd' in Command and serializes it into bytes. It dies if it

--- a/internal/curator/durable/fsm.go
+++ b/internal/curator/durable/fsm.go
@@ -98,8 +98,6 @@ func (h *StateHandler) Apply(ent raft.Entry) interface{} {
 		return c.apply(txn)
 	case UpdateStorageClassCommand:
 		return c.apply(txn)
-	case CreateTSIDCacheCommand:
-		return c.apply(txn)
 	}
 
 	log.Fatalf("applying unknown command %v", cmd)
@@ -322,8 +320,4 @@ func (cmd UpdateRSHostsCommand) apply(txn *state.Txn) core.Error {
 
 func (cmd UpdateStorageClassCommand) apply(txn *state.Txn) core.Error {
 	return txn.UpdateStorageClass(cmd.ID, cmd.Storage)
-}
-
-func (cmd CreateTSIDCacheCommand) apply(txn *state.Txn) core.Error {
-	return txn.CreateTSIDCache()
 }

--- a/internal/curator/durable/handler.go
+++ b/internal/curator/durable/handler.go
@@ -590,22 +590,8 @@ func (h *StateHandler) UpdateStorageClass(id core.BlobID, target core.StorageCla
 	return pending.Res.(core.Error)
 }
 
-// CreateTSIDCache creates the TSID cache in the state database.
-func (h *StateHandler) CreateTSIDCache() core.Error {
-	pending := h.raft.Propose(cmdToBytes(CreateTSIDCacheCommand{}))
-	select {
-	case <-time.After(core.ProposalTimeout):
-		return core.ErrRaftTimeout
-	case <-pending.Done:
-	}
-	if pending.Err != nil {
-		return core.FromRaftError(pending.Err)
-	}
-	return pending.Res.(core.Error)
-}
-
 // GetKnownTSIDs returns all the known tractserver IDs in the database.
-func (h *StateHandler) GetKnownTSIDs() ([]core.TractserverID, core.Error) {
+func (h *StateHandler) GetKnownTSIDs() []core.TractserverID {
 	txn := h.LocalReadOnlyTxn()
 	defer txn.Commit()
 	return txn.GetKnownTSIDs()

--- a/internal/curator/durable/state/state_test.go
+++ b/internal/curator/durable/state/state_test.go
@@ -391,22 +391,8 @@ func TestGetKnownTSIDs(t *testing.T) {
 	// TODO: should test PutRSChunk and UpdateRSHosts too
 
 	tx = s.ReadOnlyTxn()
-	ids, err := tx.GetKnownTSIDs()
-	if err == core.NoError {
-		t.Errorf("should not have cached tsids yet")
-	}
+	ids := tx.GetKnownTSIDs()
 	tx.Commit()
-
-	tx = s.WriteTxn(3)
-	tx.CreateTSIDCache()
-	tx.Commit()
-
-	tx = s.ReadOnlyTxn()
-	ids, err = tx.GetKnownTSIDs()
-	tx.Commit()
-	if err != core.NoError {
-		t.Errorf("doesn't have tsids")
-	}
 	if !reflect.DeepEqual(ids, []core.TractserverID{1, 5, 7, 9}) {
 		t.Errorf("mismatch: %v", ids)
 	}
@@ -417,11 +403,8 @@ func TestGetKnownTSIDs(t *testing.T) {
 	tx.Commit()
 
 	tx = s.ReadOnlyTxn()
-	ids, err = tx.GetKnownTSIDs()
+	ids = tx.GetKnownTSIDs()
 	tx.Commit()
-	if err != core.NoError {
-		t.Errorf("doesn't have tsids")
-	}
 	if !reflect.DeepEqual(ids, []core.TractserverID{1, 5, 7, 9, 11, 17}) {
 		t.Errorf("mismatch: %v", ids)
 	}


### PR DESCRIPTION
We can assume it's always present now and simplify some interfaces.

(I thought I did this before the open-source release, but I must have forgotten, or it got lost somewhere.)