### PR TITLE
Remove id field from partition values

### DIFF
--- a/internal/curator/durable/fsm_test.go
+++ b/internal/curator/durable/fsm_test.go
@@ -82,7 +82,7 @@ func TestAddPartition(t *testing.T) {
 	if len(partitions) != 1 {
 		t.Errorf("expected no partitions")
 	}
-	if partitions[0].Id() != 7 {
+	if partitions[0].ID != 7 {
 		t.Fatalf("wrong id for our partition")
 	}
 }
@@ -114,7 +114,7 @@ func TestSyncPartitions(t *testing.T) {
 
 	// Verify the values.
 	for _, part := range partitions {
-		if part.Id() != 7 && part.Id() != 2001 {
+		if part.ID != 7 && part.ID != 2001 {
 			t.Fatalf("wrong id for our partition")
 		}
 	}
@@ -154,9 +154,10 @@ func TestCreateBlob(t *testing.T) {
 	}
 
 	// Reach in and change the partition's state
-	p := txn.GetPartitions()[0].ToStruct()
-	p.NextBlobKey = core.MaxBlobKey
-	txn.PutPartition(p)
+	p := txn.GetPartitions()[0]
+	newPart := p.P.ToStruct()
+	newPart.NextBlobKey = core.MaxBlobKey
+	txn.PutPartition(p.ID, newPart)
 
 	if createCmd.apply(txn).Err == core.NoError {
 		t.Errorf("expected to fail in blob creation")
@@ -190,9 +191,10 @@ func TestPartitionAllocation(t *testing.T) {
 			t.Fatalf("error adding a partition")
 		}
 
-		p := txn.GetPartitions()[i].ToStruct()
-		p.NextBlobKey = core.MaxBlobKey
-		txn.PutPartition(p)
+		p := txn.GetPartitions()[i]
+		newPart := p.P.ToStruct()
+		newPart.NextBlobKey = core.MaxBlobKey
+		txn.PutPartition(p.ID, newPart)
 	}
 
 	// Add a non-full partition.
@@ -201,9 +203,10 @@ func TestPartitionAllocation(t *testing.T) {
 		t.Fatalf("error adding a partition")
 	}
 
-	p := txn.GetPartitions()[23].ToStruct()
-	p.NextBlobKey = 100
-	txn.PutPartition(p)
+	p := txn.GetPartitions()[23]
+	newPart := p.P.ToStruct()
+	newPart.NextBlobKey = 100
+	txn.PutPartition(p.ID, newPart)
 
 	// Create should work in the non-full partition.
 	createCmd := CreateBlobCommand{Repl: 1}
@@ -232,9 +235,10 @@ func TestExtendNoSuchBlob(t *testing.T) {
 			t.Fatalf("error adding a partition")
 		}
 
-		p := txn.GetPartitions()[i].ToStruct()
-		p.NextBlobKey = core.MaxBlobKey
-		txn.PutPartition(p)
+		p := txn.GetPartitions()[i]
+		newPart := p.P.ToStruct()
+		newPart.NextBlobKey = core.MaxBlobKey
+		txn.PutPartition(p.ID, newPart)
 	}
 
 	// Add a non-full partition.

--- a/internal/curator/durable/handler.go
+++ b/internal/curator/durable/handler.go
@@ -197,7 +197,7 @@ func (h *StateHandler) GetCuratorInfoLocal() (id core.CuratorID, partitionIDs []
 	partitions := txn.GetPartitions()
 	partitionIDs = make([]core.PartitionID, len(partitions))
 	for i, p := range partitions {
-		partitionIDs[i] = core.PartitionID(p.Id())
+		partitionIDs[i] = p.ID
 	}
 	return
 }
@@ -713,7 +713,7 @@ func (h *StateHandler) GetFreeSpaceLocal() uint64 {
 
 	var free uint64
 	for _, p := range txn.GetPartitions() {
-		free += core.MaxBlobKey - uint64(p.NextBlobKey())
+		free += core.MaxBlobKey - uint64(p.P.NextBlobKey())
 	}
 	return free
 }

--- a/internal/curator/durable/state/checksum_test.go
+++ b/internal/curator/durable/state/checksum_test.go
@@ -35,14 +35,14 @@ type putRSChunkArgs struct {
 	data    [][]EncodedTract
 }
 
-func makeState(t *testing.T, id core.CuratorID, parts []fb.Partition, blobs map[core.BlobID]fb.Blob,
+func makeState(t *testing.T, id core.CuratorID, parts map[core.PartitionID]fb.Partition, blobs map[core.BlobID]fb.Blob,
 	chunks []putRSChunkArgs) (s *State) {
 
 	s = getTestState(t)
 	txn := s.WriteTxn(1)
 	txn.SetCuratorID(id)
-	for _, p := range parts {
-		txn.PutPartition(&p)
+	for pid, p := range parts {
+		txn.PutPartition(pid, &p)
 	}
 	for bid, blob := range blobs {
 		txn.PutBlob(bid, &blob)
@@ -76,24 +76,24 @@ func TestChecksum(t *testing.T) {
 		makeState(t, 2, nil, nil, nil),
 		// 2
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 1},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 1},
 			},
 			nil,
 			nil,
 		),
 		// 3
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 2, NextBlobKey: 1},
+			map[core.PartitionID]fb.Partition{
+				2: {NextBlobKey: 1},
 			},
 			nil,
 			nil,
 		),
 		// 4
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 1},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 1},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3},
@@ -102,8 +102,8 @@ func TestChecksum(t *testing.T) {
 		),
 		// 5
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 2},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 2},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3},
@@ -112,8 +112,8 @@ func TestChecksum(t *testing.T) {
 		),
 		// 6
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 2},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 2},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3, Tracts: []*fb.Tract{
@@ -124,8 +124,8 @@ func TestChecksum(t *testing.T) {
 		),
 		// 7
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 2},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 2},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3, Tracts: []*fb.Tract{
@@ -137,8 +137,8 @@ func TestChecksum(t *testing.T) {
 		),
 		// 8
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 3},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 3},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3, Tracts: []*fb.Tract{
@@ -154,9 +154,9 @@ func TestChecksum(t *testing.T) {
 		),
 		// 9
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 3},
-				{Id: 2, NextBlobKey: 4},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 3},
+				2: {NextBlobKey: 4},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3, Tracts: []*fb.Tract{
@@ -183,8 +183,8 @@ func TestChecksum(t *testing.T) {
 		),
 		// 10 (partitions and blobs same as 7)
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 3},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 3},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3, Tracts: []*fb.Tract{
@@ -213,8 +213,8 @@ func TestChecksum(t *testing.T) {
 		),
 		// 11 (partitions and blobs same as 7, 10)
 		makeState(t, 1,
-			[]fb.Partition{
-				{Id: 1, NextBlobKey: 3},
+			map[core.PartitionID]fb.Partition{
+				1: {NextBlobKey: 3},
 			},
 			map[core.BlobID]fb.Blob{
 				core.BlobIDFromParts(1, 1): {Repl: 3, Tracts: []*fb.Tract{
@@ -266,7 +266,7 @@ func TestChecksumNext(t *testing.T) {
 	txn := s.WriteTxn(1)
 	txn.SetCuratorID(123)
 	var part core.PartitionID = 44
-	txn.PutPartition(&fb.Partition{Id: part})
+	txn.PutPartition(part, &fb.Partition{})
 	for i := 1000; i < 2000; i++ {
 		txn.PutBlob(core.BlobIDFromParts(part, core.BlobKey(i)), &fb.Blob{Repl: 3})
 	}

--- a/internal/curator/durable/state/fb/PartitionF.go
+++ b/internal/curator/durable/state/fb/PartitionF.go
@@ -26,7 +26,7 @@ func (rcv *PartitionF) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *PartitionF) Id() uint32 {
+func (rcv *PartitionF) NextBlobKey() uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.GetUint32(o + rcv._tab.Pos)
@@ -34,24 +34,12 @@ func (rcv *PartitionF) Id() uint32 {
 	return 0
 }
 
-func (rcv *PartitionF) MutateId(n uint32) bool {
+func (rcv *PartitionF) MutateNextBlobKey(n uint32) bool {
 	return rcv._tab.MutateUint32Slot(4, n)
 }
 
-func (rcv *PartitionF) NextBlobKey() uint32 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
-	if o != 0 {
-		return rcv._tab.GetUint32(o + rcv._tab.Pos)
-	}
-	return 0
-}
-
-func (rcv *PartitionF) MutateNextBlobKey(n uint32) bool {
-	return rcv._tab.MutateUint32Slot(6, n)
-}
-
 func (rcv *PartitionF) NextRsChunkKey() uint64 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		return rcv._tab.GetUint64(o + rcv._tab.Pos)
 	}
@@ -59,20 +47,17 @@ func (rcv *PartitionF) NextRsChunkKey() uint64 {
 }
 
 func (rcv *PartitionF) MutateNextRsChunkKey(n uint64) bool {
-	return rcv._tab.MutateUint64Slot(8, n)
+	return rcv._tab.MutateUint64Slot(6, n)
 }
 
 func PartitionFStart(builder *flatbuffers.Builder) {
-	builder.StartObject(3)
-}
-func PartitionFAddId(builder *flatbuffers.Builder, id uint32) {
-	builder.PrependUint32Slot(0, id, 0)
+	builder.StartObject(2)
 }
 func PartitionFAddNextBlobKey(builder *flatbuffers.Builder, nextBlobKey uint32) {
-	builder.PrependUint32Slot(1, nextBlobKey, 0)
+	builder.PrependUint32Slot(0, nextBlobKey, 0)
 }
 func PartitionFAddNextRsChunkKey(builder *flatbuffers.Builder, nextRsChunkKey uint64) {
-	builder.PrependUint64Slot(2, nextRsChunkKey, 0)
+	builder.PrependUint64Slot(1, nextRsChunkKey, 0)
 }
 func PartitionFEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/internal/curator/durable/state/fb/builders.go
+++ b/internal/curator/durable/state/fb/builders.go
@@ -13,7 +13,6 @@ import (
 func BuildPartition(p *Partition) []byte {
 	bu := flatbuffers.NewBuilder(64)
 	PartitionFStart(bu)
-	PartitionFAddId(bu, uint32(p.Id))
 	PartitionFAddNextBlobKey(bu, uint32(p.NextBlobKey))
 	PartitionFAddNextRsChunkKey(bu, p.NextRsChunkKey)
 	bu.Finish(PartitionFEnd(bu))

--- a/internal/curator/durable/state/fb/roundtrip_test.go
+++ b/internal/curator/durable/state/fb/roundtrip_test.go
@@ -13,7 +13,6 @@ import (
 // TestRoundtripPartition tests BuildPartition and PartitionF.ToStruct.
 func TestRoundtripPartition(t *testing.T) {
 	p := Partition{
-		Id:             123,
 		NextBlobKey:    456,
 		NextRsChunkKey: 789,
 	}

--- a/internal/curator/durable/state/fb/state.fbs
+++ b/internal/curator/durable/state/fb/state.fbs
@@ -13,11 +13,8 @@ struct TractIDF {
   b5: uint16;
 }
 
-// PartitionF holds data about one partition. ID is not strictly necessary since it should
-// always be determined by context, but it makes some code simpler, and there will be very
-// few of these.
+// PartitionF holds data about one partition.
 table PartitionF {
-  id: uint32;
   next_blob_key: uint32;
   next_rs_chunk_key: uint64; // 48 bits of "blob key" and "tract index" in one value
 }

--- a/internal/curator/durable/state/fb/structs.go
+++ b/internal/curator/durable/state/fb/structs.go
@@ -34,7 +34,6 @@ type Blob struct {
 
 // Partition is the struct version of PartitionF.
 type Partition struct {
-	Id             core.PartitionID
 	NextBlobKey    core.BlobKey
 	NextRsChunkKey uint64 // 48 bits of "blob key" and "tract index" in one value
 }

--- a/internal/curator/durable/state/fb/unbuilders.go
+++ b/internal/curator/durable/state/fb/unbuilders.go
@@ -49,7 +49,6 @@ func (b *BlobF) ToStruct() (o *Blob) {
 // ToStruct creates a Blob from a BlobF.
 func (p *PartitionF) ToStruct() (o *Partition) {
 	o = new(Partition)
-	o.Id = core.PartitionID(p.Id())
 	o.NextBlobKey = core.BlobKey(p.NextBlobKey())
 	o.NextRsChunkKey = p.NextRsChunkKey()
 	return

--- a/internal/curator/durable/state/snapshot_test.go
+++ b/internal/curator/durable/state/snapshot_test.go
@@ -24,8 +24,8 @@ func TestStateSnapshot(t *testing.T) {
 
 	txn := s1.WriteTxn(1)
 	txn.SetCuratorID(1)
-	txn.PutPartition(&fb.Partition{Id: 1})
-	txn.PutPartition(&fb.Partition{Id: 3})
+	txn.PutPartition(1, &fb.Partition{})
+	txn.PutPartition(3, &fb.Partition{})
 	txn.PutBlob(core.BlobIDFromParts(1, 1), &fb.Blob{Repl: 3})
 	txn.PutBlob(core.BlobIDFromParts(1, 2), &fb.Blob{Repl: 3})
 	txn.PutBlob(core.BlobIDFromParts(3, 1), &fb.Blob{Repl: 3})

--- a/internal/curator/durable/state/state_test.go
+++ b/internal/curator/durable/state/state_test.go
@@ -38,8 +38,8 @@ func TestStateBasics(t *testing.T) {
 	}
 
 	// Create two partitions.
-	txn.PutPartition(&fb.Partition{Id: 1})
-	txn.PutPartition(&fb.Partition{Id: 3})
+	txn.PutPartition(1, &fb.Partition{})
+	txn.PutPartition(3, &fb.Partition{})
 
 	// Create two blobs in partition 1.
 	txn.PutBlob(core.BlobIDFromParts(1, 1), &fb.Blob{Repl: 3})
@@ -56,7 +56,7 @@ func TestStateBasics(t *testing.T) {
 	if len(partitions) != 2 {
 		t.Fatalf("expected to get two partitions")
 	}
-	if partitions[0].Id() != 1 || partitions[1].Id() != 3 {
+	if partitions[0].ID != 1 || partitions[1].ID != 3 {
 		t.Fatalf("unexpected partition IDs returned")
 	}
 	if txn.GetPartition(3) == nil {
@@ -99,8 +99,8 @@ func TestStateBlobIterator(t *testing.T) {
 	txn := s.WriteTxn(1)
 
 	// Create two partitions.
-	txn.PutPartition(&fb.Partition{Id: 1})
-	txn.PutPartition(&fb.Partition{Id: 3})
+	txn.PutPartition(1, &fb.Partition{})
+	txn.PutPartition(3, &fb.Partition{})
 
 	txn.PutBlob(core.BlobIDFromParts(3, 2), &fb.Blob{Repl: 3})
 	txn.PutBlob(core.BlobIDFromParts(3, 1), &fb.Blob{Repl: 3})
@@ -136,7 +136,7 @@ func TestStateReadWriteIsolation(t *testing.T) {
 
 	writeTxn := s.WriteTxn(1)
 	// Create partition 1.
-	writeTxn.PutPartition(&fb.Partition{Id: 1})
+	writeTxn.PutPartition(1, &fb.Partition{})
 	// Create a blob.
 	writeTxn.PutBlob(core.BlobIDFromParts(1, 1), &fb.Blob{Repl: 3})
 
@@ -181,7 +181,7 @@ func TestMultipleWriteTxns(t *testing.T) {
 
 	writeTxn := s.WriteTxn(1)
 	// Create partition 1.
-	writeTxn.PutPartition(&fb.Partition{Id: 1})
+	writeTxn.PutPartition(1, &fb.Partition{})
 	writeTxn.Commit()
 
 	writeTxn = s.WriteTxn(2)
@@ -212,7 +212,7 @@ func TestUpdateTimes(t *testing.T) {
 	defer s.Close()
 
 	txn := s.WriteTxn(1)
-	txn.PutPartition(&fb.Partition{Id: 3})
+	txn.PutPartition(3, &fb.Partition{})
 	txn.PutBlob(core.BlobIDFromParts(3, 1), &fb.Blob{Repl: 3, Mtime: 200e9, Atime: 200e9})
 	txn.PutBlob(core.BlobIDFromParts(3, 2), &fb.Blob{Repl: 3, Mtime: 200e9, Atime: 200e9})
 	txn.Commit()
@@ -337,7 +337,7 @@ func TestDeleteTractFromRSChunk(t *testing.T) {
 	bid := core.BlobIDFromParts(7, 3)
 	tid := core.TractIDFromParts(bid, 0)
 	cid := core.RSChunkID{Partition: 0x80000007, ID: 5}
-	txn.PutPartition(&fb.Partition{Id: 7})
+	txn.PutPartition(7, &fb.Partition{})
 	txn.PutBlob(bid, &fb.Blob{
 		Tracts: []*fb.Tract{
 			{Version: 1},
@@ -378,7 +378,7 @@ func TestGetKnownTSIDs(t *testing.T) {
 	defer s.Close()
 
 	tx := s.WriteTxn(1)
-	tx.PutPartition(&fb.Partition{Id: 1})
+	tx.PutPartition(1, &fb.Partition{})
 	tx.PutBlob(core.BlobIDFromParts(1, 1), &fb.Blob{Repl: 3,
 		Tracts: []*fb.Tract{{Hosts: []core.TractserverID{1, 5, 7}}}})
 	tx.Commit()


### PR DESCRIPTION
It doesn't make much sense for a value in a database to store its own
key. We can also set NextRsChunkKey when creating partitions and assume
it's always nonzero.