### PR TITLE
Backup requests replicated

### DIFF
--- a/client/blb/client.go
+++ b/client/blb/client.go
@@ -1126,7 +1126,10 @@ func (cli *Client) readOneTractReplicated(
 			continue
 		}
 
-		otherHosts := tract.Hosts
+		// Compute alternate hosts that will receive backup requests. Pass them along
+		// to the tracserver rpc layer to enable cancellation messages to be sent between
+		// servers.
+		otherHosts := cutSlice(tract.Hosts, n)
 
 		var read int
 		read, err = cli.tractservers.ReadInto(ctx, host, otherHosts, reqID, tract.Tract, tract.Version, thisB, thisOffset)
@@ -1437,4 +1440,11 @@ func priorityFromContext(ctx context.Context) core.Priority {
 		return pri
 	}
 	return core.Priority_TSDEFAULT
+}
+
+func cutSlice(s []string, i int) []string {
+	r := make([]string, len(s))
+	copy(r, s)
+	r[i], r[len(r)-1] = r[len(r)-1], r[i]
+	return r[:len(r)-1]
 }

--- a/client/blb/client.go
+++ b/client/blb/client.go
@@ -1126,8 +1126,10 @@ func (cli *Client) readOneTractReplicated(
 			continue
 		}
 
+		otherHosts := tract.Hosts
+
 		var read int
-		read, err = cli.tractservers.ReadInto(ctx, host, reqID, tract.Tract, tract.Version, thisB, thisOffset, candidateHosts)
+		read, err = cli.tractservers.ReadInto(ctx, host, otherHosts, reqID, tract.Tract, tract.Version, thisB, thisOffset)
 		if err == core.ErrVersionMismatch {
 			badVersionHost = host
 		}
@@ -1170,7 +1172,7 @@ func (cli *Client) readOneTractRS(
 	length := min(len(thisB), int(tract.RS.Length))
 	offset := int64(tract.RS.Offset) + thisOffset
 	reqID := core.GenRequestID()
-	read, err := cli.tractservers.ReadInto(ctx, tract.RS.Host, reqID, rsTract, core.RSChunkVersion, thisB[:length], offset)
+	read, err := cli.tractservers.ReadInto(ctx, tract.RS.Host, nil, reqID, rsTract, core.RSChunkVersion, thisB[:length], offset)
 
 	if err != core.NoError && err != core.ErrEOF {
 		log.V(1).Infof("rs read %s from tractserver at address %s: %s", tract.Tract, tract.RS.Host, err)

--- a/client/blb/client.go
+++ b/client/blb/client.go
@@ -81,6 +81,9 @@ type Options struct {
 
 	// How the client decides whether to attempt client-side RS reconstruction.
 	ReconstructBehavior ReconstructBehavior
+
+	// Wether client will send backup reads if the primary read is delayed.
+	DisableBackupReads bool
 }
 
 // Client exposes a simple interface to Blb users for requesting services and
@@ -115,6 +118,9 @@ type Client struct {
 
 	// Reconstruct behavior.
 	reconstructState reconstructState
+
+	// Wether to use backup reads or not.
+	backupReadsDisabled bool
 
 	// Metrics we collect.
 	metricOpen           prometheus.Observer
@@ -165,6 +171,7 @@ func newBaseClient(options *Options) *Client {
 		cluster:              options.Cluster,
 		retrier:              retrier,
 		reconstructState:     makeReconstructState(options.ReconstructBehavior),
+		backupReadsDisabled:  options.DisableBackupReads,
 		metricOpen:           clientOpLatenciesSet.WithLabelValues("open", options.Instance),
 		metricCreate:         clientOpLatenciesSet.WithLabelValues("create", options.Instance),
 		metricReadDurations:  clientOpLatenciesSet.WithLabelValues("read", options.Instance),
@@ -1095,7 +1102,11 @@ func (cli *Client) readOneTract(
 	defer sem.Release()
 
 	if len(tract.Hosts) > 0 {
-		cli.readOneTractReplicated(ctx, curAddr, result, tract, thisB, thisOffset)
+		if cli.backupReadsDisabled {
+			cli.readOneTractReplicated(ctx, curAddr, result, tract, thisB, thisOffset)
+		} else {
+			cli.readOneTractWithBackupReplicated(ctx, curAddr, result, tract, thisB, thisOffset)
+		}
 	} else if tract.RS.Present() {
 		cli.readOneTractRS(ctx, curAddr, result, tract, thisB, thisOffset)
 	} else {
@@ -1115,9 +1126,6 @@ func (cli *Client) readOneTractReplicated(
 
 	order := rand.Perm(len(tract.Hosts))
 
-	// Generate a request ID to use for cancelling alternate requests.
-	reqID := core.GenRequestID()
-
 	err := core.ErrAllocHost // default error if none present
 	for _, n := range order {
 		host := tract.Hosts[n]
@@ -1126,13 +1134,8 @@ func (cli *Client) readOneTractReplicated(
 			continue
 		}
 
-		// Compute alternate hosts that will receive backup requests. Pass them along
-		// to the tracserver rpc layer to enable cancellation messages to be sent between
-		// servers.
-		otherHosts := cutSlice(tract.Hosts, n)
-
 		var read int
-		read, err = cli.tractservers.ReadInto(ctx, host, otherHosts, reqID, tract.Tract, tract.Version, thisB, thisOffset)
+		read, err = cli.tractservers.ReadInto(ctx, host, nil, "", tract.Tract, tract.Version, thisB, thisOffset)
 		if err == core.ErrVersionMismatch {
 			badVersionHost = host
 		}
@@ -1161,6 +1164,93 @@ func (cli *Client) readOneTractReplicated(
 
 	log.V(1).Infof("read %s all hosts failed", tract.Tract)
 	*result = tractResult{0, 0, err, badVersionHost}
+}
+
+func (cli *Client) readOneTractWithBackupReplicated(
+	ctx context.Context,
+	curAddr string,
+	result *tractResult,
+	tract *core.TractInfo,
+	thisB []byte,
+	thisOffset int64) {
+
+	var badVersionHost string
+
+	order := rand.Perm(len(tract.Hosts))
+
+	// Generate a request ID to use for cancelling alternate requests.
+	reqID := core.GenRequestID()
+
+	ch := make(chan tractResult)
+	errc := make(chan core.Error)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	err := core.ErrAllocHost // default error if none present
+	for i, n := range order {
+		go func(i, j int) {
+			select {
+			case <-ctx.Done():
+				errc <- core.ErrCanceled
+				return
+			case <-time.After(time.Duration(2*i) * time.Millisecond):
+			}
+			host := tract.Hosts[j]
+			if host == "" {
+				log.V(1).Infof("read %s from tsid %d: no host", tract.Tract, tract.TSIDs[j])
+				return
+			}
+
+			// Compute alternate hosts that will receive backup requests. Pass them along
+			// to the tracserver rpc layer to enable cancellation messages to be sent between
+			// servers. TODO(eric): come up with a better name for this.
+			otherHosts := cutSlice(tract.Hosts, j)
+
+			var read int
+			read, err = cli.tractservers.ReadInto(ctx, host, otherHosts, reqID, tract.Tract, tract.Version, thisB, thisOffset)
+			if err == core.ErrVersionMismatch {
+				badVersionHost = host
+			}
+			if err != core.NoError && err != core.ErrEOF {
+				log.V(1).Infof("read %s from tractserver at address %s: %s", tract.Tract, host, err)
+				errc <- err
+				// If we failed to read from a TS, report that to the curator. Defer so we can examine
+				// result.err at the end, to see if we succeeded on another or not.
+				defer func(host string, err core.Error) {
+					couldRecover := result.err == core.NoError || result.err == core.ErrEOF
+					go cli.curators.ReportBadTS(context.Background(), curAddr, tract.Tract, host, "read", err, couldRecover)
+				}(host, err)
+				return // try another host
+			}
+			log.V(1).Infof("read %s from tractserver at address %s: %s", tract.Tract, host, err)
+			// In case of short read, i.e., read < len(thisB), we should
+			// pad the result with 0's. This doesn't need to be done
+			// explicitly if 'thisB' given to us starts to be empty.
+			// However, just in case it's not, we will ensure that by
+			// overwritting untouched bytes with 0's.
+			for i := read; i < len(thisB); i++ {
+				thisB[i] = 0
+			}
+			ch <- tractResult{len(thisB), read, err, badVersionHost}
+			return
+		}(i, n)
+	}
+	// block until one goroutine finishes, or all fail due to errors.
+	nerr := 0
+	for {
+		select {
+		case *result = <-ch:
+			return
+		case err = <-errc:
+			nerr++
+			if nerr == len(order) {
+				log.V(1).Infof("read %s all hosts failed", tract.Tract)
+				*result = tractResult{0, 0, err, badVersionHost}
+				return
+			}
+		}
+	}
+	return // unreachable
 }
 
 func (cli *Client) readOneTractRS(

--- a/client/blb/client_test.go
+++ b/client/blb/client_test.go
@@ -73,8 +73,9 @@ func (log *tsTraceLog) check(t *testing.T, write bool, addr string, version, len
 // later.
 func newClient(trace tsTraceFunc) *Client {
 	options := Options{
-		DisableRetry: true,
-		DisableCache: true,
+		DisableRetry:       true,
+		DisableCache:       true,
+		DisableBackupReads: true,
 	}
 	cli := newBaseClient(&options)
 	cli.master = newMemMasterConnection([]string{"1", "2", "3"})

--- a/client/blb/mem_tractserver_talker.go
+++ b/client/blb/mem_tractserver_talker.go
@@ -5,8 +5,9 @@ package blb
 
 import (
 	"context"
-	"github.com/westerndigitalcorporation/blb/internal/core"
 	"sync"
+
+	"github.com/westerndigitalcorporation/blb/internal/core"
 )
 
 // A tsTraceEntry contains the args for a read or write on a tractserver (but
@@ -123,7 +124,7 @@ func copySlice(b []byte) []byte {
 }
 
 // ReadInto reads from a given tract.
-func (tt *memTractserverTalker) ReadInto(ctx context.Context, addr string, id core.TractID, version int, b []byte, off int64) (int, core.Error) {
+func (tt *memTractserverTalker) ReadInto(ctx context.Context, addr string, otherHosts []string, reqID string, id core.TractID, version int, b []byte, off int64) (int, core.Error) {
 	r, err := tt.Read(ctx, addr, id, version, len(b), off)
 	return copy(b, r), err
 }

--- a/client/blb/rpc_tractserver_talker.go
+++ b/client/blb/rpc_tractserver_talker.go
@@ -82,7 +82,7 @@ func (r *RPCTractserverTalker) Read(ctx context.Context, addr string, id core.Tr
 // ReadInto reads from a tract into a provided slice without copying.
 func (r *RPCTractserverTalker) ReadInto(ctx context.Context, addr string, otherHosts []string, reqID string, id core.TractID, version int, b []byte, off int64) (int, core.Error) {
 	pri := priorityFromContext(ctx)
-	req := core.ReadReq{ID: id, Version: version, Len: len(b), Off: off, Pri: pri, ReqID: reqID}
+	req := core.ReadReq{ID: id, Version: version, Len: len(b), Off: off, Pri: pri, ReqID: reqID, OtherHosts: otherHosts}
 	// Gob will decode into a provided slice if there's enough capacity. Give it b,
 	// but reset the cap to len so it can't go past our segment.
 	var reply core.ReadReply

--- a/client/blb/rpc_tractserver_talker.go
+++ b/client/blb/rpc_tractserver_talker.go
@@ -80,7 +80,7 @@ func (r *RPCTractserverTalker) Read(ctx context.Context, addr string, id core.Tr
 }
 
 // ReadInto reads from a tract into a provided slice without copying.
-func (r *RPCTractserverTalker) ReadInto(ctx context.Context, addr, reqID string, id core.TractID, version int, b []byte, off int64) (int, core.Error) {
+func (r *RPCTractserverTalker) ReadInto(ctx context.Context, addr string, otherHosts []string, reqID string, id core.TractID, version int, b []byte, off int64) (int, core.Error) {
 	pri := priorityFromContext(ctx)
 	req := core.ReadReq{ID: id, Version: version, Len: len(b), Off: off, Pri: pri, ReqID: reqID}
 	// Gob will decode into a provided slice if there's enough capacity. Give it b,

--- a/client/blb/tractserver_talker.go
+++ b/client/blb/tractserver_talker.go
@@ -5,6 +5,7 @@ package blb
 
 import (
 	"context"
+
 	"github.com/westerndigitalcorporation/blb/internal/core"
 )
 
@@ -22,7 +23,7 @@ type TractserverTalker interface {
 
 	// ReadInto reads from a tract. It will try to read up to len(b) bytes and put them in b.
 	// It returns the number of bytes read, as in io.Reader's Read.
-	ReadInto(ctx context.Context, addr string, reqID string, core.id core.TractID, version int, b []byte, off int64) (int, core.Error)
+	ReadInto(ctx context.Context, addr string, otherHosts []string, reqID string, id core.TractID, version int, b []byte, off int64) (int, core.Error)
 
 	// StatTract returns the number of bytes in a tract.
 	StatTract(ctx context.Context, addr string, id core.TractID, version int) (int64, core.Error)

--- a/client/blb/tractserver_talker.go
+++ b/client/blb/tractserver_talker.go
@@ -22,7 +22,7 @@ type TractserverTalker interface {
 
 	// ReadInto reads from a tract. It will try to read up to len(b) bytes and put them in b.
 	// It returns the number of bytes read, as in io.Reader's Read.
-	ReadInto(ctx context.Context, addr string, id core.TractID, version int, b []byte, off int64) (int, core.Error)
+	ReadInto(ctx context.Context, addr string, reqID string, core.id core.TractID, version int, b []byte, off int64) (int, core.Error)
 
 	// StatTract returns the number of bytes in a tract.
 	StatTract(ctx context.Context, addr string, id core.TractID, version int) (int64, core.Error)

--- a/internal/core/genreqid.go
+++ b/internal/core/genreqid.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+package core
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"strconv"
+	"sync/atomic"
+)
+
+var (
+	clientIDPrefix = makePrefix()
+	seqNum         uint64
+)
+
+func makePrefix() string {
+	buf := make([]byte, 15)
+	rand.Buf(buf)
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// GenRequestID returns a unique string to be used as a request id for cancellation. This
+// implementation works by using 120 random bits as a process identitifer combined with
+// 64 random bits of a sequence number. The values that it produces are printable (though things
+// should work regadless).
+func GenRequestID() string {
+	id := atomic.AddUint64(&seqNum, 1)
+	return clientIDPrefix + strconv.FormatUint(id, 36)
+}

--- a/internal/core/genreqid.go
+++ b/internal/core/genreqid.go
@@ -16,7 +16,7 @@ var (
 
 func makePrefix() string {
 	buf := make([]byte, 15)
-	rand.Buf(buf)
+	rand.Read(buf)
 	return base64.StdEncoding.EncodeToString(buf)
 }
 

--- a/internal/core/tractserver_messages.go
+++ b/internal/core/tractserver_messages.go
@@ -227,6 +227,10 @@ type ReadReq struct {
 
 	// ID for cancellation.
 	ReqID string
+
+	// Other replicas that can serve the read for backup requets
+	// how about the other ReqIDs?
+	ReplicaHosts []string
 }
 
 // ReadReply is the reply for ReadReq.

--- a/internal/core/tractserver_messages.go
+++ b/internal/core/tractserver_messages.go
@@ -228,9 +228,8 @@ type ReadReq struct {
 	// ID for cancellation.
 	ReqID string
 
-	// Other replicas that can serve the read for backup requets
-	// how about the other ReqIDs?
-	ReplicaHosts []string
+	// Other replicas that can serve alternate reads.
+	OtherHosts []string
 }
 
 // ReadReply is the reply for ReadReq.


### PR DESCRIPTION
This is an implementation of client backup requests for replicated storage. The set of primary and backup requests are now marked with a new application-level requestID, a constant across the group. Additionally, the set of "other" backup hosts that may be working on a given read is also added to rpc requests so when it comes time to cancel work, a tractserver knows which host(s) to send cancellation rpcs to. The work for tractserver-to-tractserver cancellation still needs to done using this new request ID in a later PR.